### PR TITLE
completions deprecated, use complete instead

### DIFF
--- a/spylon_kernel/init_spark_magic.py
+++ b/spylon_kernel/init_spark_magic.py
@@ -86,6 +86,6 @@ class InitSparkMagic(Magic):
         )
 
         before = text[:len(text) - len(name)]
-        completions = interpreter.completions()
+        completions = interpreter.complete()
         completions = [before + c.name_with_symbols for c in completions]
         return [c[info['start']:] for c in completions]


### PR DESCRIPTION
completions deprecated, use complete instead
https://jedi.readthedocs.io/en/latest/docs/changelog.html
https://github.com/bjornjorgensen/spylon-kernel/blob/7668fda9f7a1526d06bedc7dcc7a4f6259e985b6/spylon_kernel/init_spark_magic.py#LL89C40-L89C40